### PR TITLE
Feature Mr D and SA payment processor articles

### DIFF
--- a/cv-fde/index.html
+++ b/cv-fde/index.html
@@ -333,17 +333,6 @@
           <div class="grid grid-cols-2 gap-3">
             
             <div class="project-card border border-gray-200 rounded-lg p-3">
-              <p class="text-xs font-semibold text-gray-800 leading-snug">GitGuardian AX Audit</p>
-              <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">AI/ML</span>
-              
-              <p class="text-xs text-gray-500">Four-stage agent experience audit: designed test plan, ran structured Claude Code sessions, built evaluation framework, published scored report.</p>
-              
-              
-              <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/articles/gitguardian-ax-audit/" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
-              
-            </div>
-            
-            <div class="project-card border border-gray-200 rounded-lg p-3">
               <p class="text-xs font-semibold text-gray-800 leading-snug">Letta Multi-Agent Pattern Guides</p>
               <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">AI/ML</span>
               
@@ -379,23 +368,34 @@
             <div class="project-card border border-gray-200 rounded-lg p-3">
               <p class="text-xs font-semibold text-gray-800 leading-snug">VirtualFit Telegram Bot</p>
               <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">Full-Stack</span>
-              
+
               <p class="text-xs text-gray-500">Production Telegram bot using Black Forest Labs FLUX.2 API for photorealistic outfit try-ons.</p>
-              
-              
+
+
               <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/guides/build-telegram-try-on-bot-black-forest-labs/" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
-              
+
             </div>
-            
+
             <div class="project-card border border-gray-200 rounded-lg p-3">
-              <p class="text-xs font-semibold text-gray-800 leading-snug">Building a Full Stack App With Express and HTMx</p>
-              <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">Full-Stack</span>
-              
-              <p class="text-xs text-gray-500">Top Google search result for HTMx/Express tutorials.</p>
-              
-              
-              <a target="_blank" rel="noopener noreferrer" href="https://codecapsules.io/tutorial/building-a-full-stack-application-with-express-and-htmx/" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
-              
+              <p class="text-xs font-semibold text-gray-800 leading-snug">Can My AI Agent Order Me a Burger With Mr D?</p>
+              <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">AI/ML</span>
+
+              <p class="text-xs text-gray-500">Reverse-engineered a private delivery API and built an MCP server so an agent can order end to end.</p>
+
+
+              <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/articles/mr-d-agentic-ordering-ax/" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
+
+            </div>
+
+            <div class="project-card border border-gray-200 rounded-lg p-3">
+              <p class="text-xs font-semibold text-gray-800 leading-snug">Which Payment Processor Do AI Agents Recommend?</p>
+              <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">AI/ML</span>
+
+              <p class="text-xs text-gray-500">Agent experience comparison of Yoco, PayFast, and Paystack, tested from primary sources.</p>
+
+
+              <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/articles/sa-payment-processors-ax-comparison/" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
+
             </div>
             
           </div>

--- a/cv/index.html
+++ b/cv/index.html
@@ -387,36 +387,25 @@
             </div>
             
             <div class="project-card border border-gray-200 rounded-lg p-3">
-              <p class="text-xs font-semibold text-gray-800 leading-snug">JavaScript-Outlook Calendar Sync</p>
-              <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">Integration</span>
-              
-              <p class="text-xs text-gray-500">Full calendar synchronization using Microsoft Graph API.</p>
-              
-              
-              <a target="_blank" rel="noopener noreferrer" href="https://bryntum.com/blog/how-to-connect-and-sync-bryntum-scheduler-to-microsoft-teams/" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
-              
+              <p class="text-xs font-semibold text-gray-800 leading-snug">Can My AI Agent Order Me a Burger With Mr D?</p>
+              <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">AI/ML</span>
+
+              <p class="text-xs text-gray-500">Reverse-engineered a private delivery API and built an MCP server so an agent can order end to end.</p>
+
+
+              <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/articles/mr-d-agentic-ordering-ax/" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
+
             </div>
-            
+
             <div class="project-card border border-gray-200 rounded-lg p-3">
-              <p class="text-xs font-semibold text-gray-800 leading-snug">Flask-Redis Full-Stack App</p>
-              <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">Full-Stack</span>
-              
-              <p class="text-xs text-gray-500">Web application with Redis caching and complete documentation.</p>
-              
-              
-              <a target="_blank" rel="noopener noreferrer" href="https://codecapsules.io/tutorial/building-a-reader-mode-full-stack-application-with-flask-and-redis/" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
-              
-            </div>
-            
-            <div class="project-card border border-gray-200 rounded-lg p-3">
-              <p class="text-xs font-semibold text-gray-800 leading-snug">Revisiting the Design of the Zig Language</p>
-              <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">Technical Analysis</span>
-              
-              <p class="text-xs text-gray-500">Featured on Hacker News front page.</p>
-              
-              
-              <a target="_blank" rel="noopener noreferrer" href="https://sourcegraph.com/blog/zig-programming-language-revisiting-design-approach" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
-              
+              <p class="text-xs font-semibold text-gray-800 leading-snug">Which Payment Processor Do AI Agents Recommend?</p>
+              <span class="inline-block text-xs bg-gray-100 text-gray-500 rounded px-1.5 py-0.5 mt-1 mb-1">AI/ML</span>
+
+              <p class="text-xs text-gray-500">Agent experience comparison of Yoco, PayFast, and Paystack, tested from primary sources.</p>
+
+
+              <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/articles/sa-payment-processors-ax-comparison/" class="text-xs text-blue-500 mt-1 hover:underline">Link</a>
+
             </div>
             
           </div>

--- a/portfolio-fde/index.html
+++ b/portfolio-fde/index.html
@@ -364,6 +364,16 @@
             <span class="text-gray-400 mt-0.5 flex-shrink-0">&#8226;</span>
             <span>
 
+              <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/articles/mr-d-agentic-ordering-ax/" class="text-blue-600 hover:underline">Can My AI Agent Order Me a Burger With Mr D?</a>
+
+
+            </span>
+          </li>
+
+          <li class="flex gap-2 text-sm">
+            <span class="text-gray-400 mt-0.5 flex-shrink-0">&#8226;</span>
+            <span>
+
               <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/articles/bobpay-peach-ozow-payu-ax-comparison/" class="text-blue-600 hover:underline">Which Payment Processor Do AI Agents Recommend? Bobpay vs Peach Payments vs Ozow vs PayU</a>
 
 

--- a/technical-writing-portfolio/index.html
+++ b/technical-writing-portfolio/index.html
@@ -364,6 +364,16 @@
             <span class="text-gray-400 mt-0.5 flex-shrink-0">&#8226;</span>
             <span>
 
+              <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/articles/mr-d-agentic-ordering-ax/" class="text-blue-600 hover:underline">Can My AI Agent Order Me a Burger With Mr D?</a>
+
+
+            </span>
+          </li>
+
+          <li class="flex gap-2 text-sm">
+            <span class="text-gray-400 mt-0.5 flex-shrink-0">&#8226;</span>
+            <span>
+
               <a target="_blank" rel="noopener noreferrer" href="https://techstackups.com/articles/bobpay-peach-ozow-payu-ax-comparison/" class="text-blue-600 hover:underline">Which Payment Processor Do AI Agents Recommend? Bobpay vs Peach Payments vs Ozow vs PayU</a>
 
 


### PR DESCRIPTION
Refreshes the featured projects on both CVs with two recent agent-experience articles, and adds the Mr D piece to both portfolios.

## Added

- **Can My AI Agent Order Me a Burger With Mr D?** — reverse-engineered a private delivery API and built an MCP server so an agent can order end to end. Added to both CVs and both portfolios.
- **Which Payment Processor Do AI Agents Recommend? (Yoco vs PayFast vs Paystack)** — added to both CVs. Already present in the portfolios.

## Removed

| Page | Removed | Why |
|---|---|---|
| `cv/` | Flask-Redis, Outlook Calendar Sync | Oldest, most generic tutorial work |
| `cv/` | Revisiting the Design of the Zig Language | Per request, CV only. Still in both portfolios. |
| `cv-fde/` | Express + HTMx tutorial | Beginner tutorial, weakest fit for an FDE role |
| `cv-fde/` | GitGuardian AX Audit | Per request |

VirtualFit Telegram Bot was kept on `cv-fde/`.

Both CVs now sit at an even card count for the two-column grid: `cv/` has 5, `cv-fde/` has 6.

## Note

The checked-in PDFs are still not regenerated and remain out of sync with these pages.